### PR TITLE
Use new Travis CI container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: java
+sudo: false
 jdk:
-  - openjdk6
+  - openjdk7


### PR DESCRIPTION
Should speed up the build:
http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

Also building with OpenJDK7 instead of 6

Signed-off-by: Chris Aniszczyk <zx@twitter.com>