### PR TITLE
Lock down versions for dependencies

### DIFF
--- a/ch-commons-util/pom.xml
+++ b/ch-commons-util/pom.xml
@@ -54,8 +54,8 @@
   <properties>
     <main.java.package>com.cloudhopper.commons.util</main.java.package>
     <junit.version>4.10</junit.version>
-    <joda-time.version>[2.0,)</joda-time.version>
-    <slf4j.version>[1.7,)</slf4j.version>
-    <logback.version>[1.0,)</logback.version>
+    <joda-time.version>2.8.2</joda-time.version>
+    <slf4j.version>1.7.21</slf4j.version>
+    <logback.version>1.1.7</logback.version>
   </properties>
 </project>


### PR DESCRIPTION
SLF4J has released an experimental 1.8.0-alpha0 version which is backwards incompatible with other slf4j packages. The current versioning structure will introduce this as dependencies and break