### PR TITLE
Add hamcrest matcher test dependency

### DIFF
--- a/ch-commons-charset/pom.xml
+++ b/ch-commons-charset/pom.xml
@@ -33,6 +33,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
       <version>${logback.version}</version>

--- a/ch-commons-gsm/pom.xml
+++ b/ch-commons-gsm/pom.xml
@@ -33,6 +33,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
       <version>${logback.version}</version>

--- a/ch-commons-locale/pom.xml
+++ b/ch-commons-locale/pom.xml
@@ -37,6 +37,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
       <version>${logback.version}</version>

--- a/ch-commons-sql/pom.xml
+++ b/ch-commons-sql/pom.xml
@@ -63,6 +63,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
       <version>${logback.version}</version>

--- a/ch-commons-ssl/pom.xml
+++ b/ch-commons-ssl/pom.xml
@@ -33,6 +33,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
       <version>${logback.version}</version>

--- a/ch-commons-xbean/pom.xml
+++ b/ch-commons-xbean/pom.xml
@@ -38,6 +38,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
       <version>${slf4j.version}</version>

--- a/ch-maven-parent-oss/pom.xml
+++ b/ch-maven-parent-oss/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.cloudhopper</groupId>
   <artifactId>ch-maven-parent-oss</artifactId>
   <packaging>pom</packaging>
-  <version>1.6</version>
+  <version>1.7</version>
   <name>ch-maven-parent-oss</name>
   <description>Parent Maven POM for open source Cloudhopper projects</description>
   <url>https://github.com/twitter/cloudhopper-commons</url>
@@ -356,7 +356,7 @@
     <!-- Maven config -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <copyright.year>2016</copyright.year>
+    <copyright.year>2017</copyright.year>
     <maven.test.skip>false</maven.test.skip>
     <maven.integration.skip>true</maven.integration.skip>
     <license.skip>false</license.skip>
@@ -376,6 +376,7 @@
     <logback.version>[1.0,)</logback.version>
     <netty.version>[3.2,)</netty.version>
     <slf4j.version>[1.5.0,)</slf4j.version>
+    <hamcrest.version>1.3</hamcrest.version>
   </properties>
 
 </project>

--- a/ch-maven-parent-oss/pom.xml
+++ b/ch-maven-parent-oss/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.cloudhopper</groupId>
   <artifactId>ch-maven-parent-oss</artifactId>
   <packaging>pom</packaging>
-  <version>1.7</version>
+  <version>1.7-SNAPSHOT</version>
   <name>ch-maven-parent-oss</name>
   <description>Parent Maven POM for open source Cloudhopper projects</description>
   <url>https://github.com/twitter/cloudhopper-commons</url>

--- a/ch-sxmp/pom.xml
+++ b/ch-sxmp/pom.xml
@@ -87,6 +87,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>xmlunit</groupId>
       <artifactId>xmlunit</artifactId>
       <version>[1.3,)</version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,8 @@
   <parent>
     <groupId>com.cloudhopper</groupId>
     <artifactId>ch-maven-parent-oss</artifactId>
-    <version>1.7</version>
+    <relativePath>ch-maven-parent-oss</relativePath>
+    <version>1.7-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.cloudhopper</groupId>
     <artifactId>ch-maven-parent-oss</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
   </parent>
 
   <modules>


### PR DESCRIPTION
Hamcrest matchers are split off in their own artifact now. Add test
dependency across cloudhopper-commons