### PR TITLE
Add optional StatisticsHandler to jetty server

### DIFF
--- a/ch-jetty/src/main/java/com/cloudhopper/jetty/HttpServerConfiguration.java
+++ b/ch-jetty/src/main/java/com/cloudhopper/jetty/HttpServerConfiguration.java
@@ -56,6 +56,8 @@ public class HttpServerConfiguration {
     protected boolean jettyAutoShutdownDisabled;
     // jmx domain to use for mbean
     protected String jmxDomain;
+    // should we track request stats?
+    protected Boolean requestStatsEnabled;
     
     public HttpServerConfiguration() {
         this.sessionsEnabled = true;
@@ -65,7 +67,8 @@ public class HttpServerConfiguration {
         this.maxThreads = 50;
         this.threadKeepAliveTimeout = 60000;
         this.jettyAutoShutdownDisabled = false;
-	this.jmxDomain = "com.cloudhopper.jetty." + safeGetName();
+        this.jmxDomain = "com.cloudhopper.jetty." + safeGetName();
+        this.requestStatsEnabled = false;
     }
 
     public String getResourceBaseDirectory() {
@@ -198,5 +201,13 @@ public class HttpServerConfiguration {
     public String getJmxDomain() {
         return this.jmxDomain;
     }
-    
+
+    public Boolean isRequestStatsEnabled() {
+        return requestStatsEnabled;
+    }
+
+    public void setRequestStatsEnabled(Boolean requestStatsEnabled) {
+        this.requestStatsEnabled = requestStatsEnabled;
+    }
+
 }

--- a/ch-jetty/src/main/java/com/cloudhopper/jetty/JettyHttpServer.java
+++ b/ch-jetty/src/main/java/com/cloudhopper/jetty/JettyHttpServer.java
@@ -21,7 +21,6 @@ package com.cloudhopper.jetty;
  */
 
 import com.cloudhopper.commons.util.CountingRejectedExecutionHandler;
-import com.cloudhopper.commons.util.NamingThreadFactory;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import javax.servlet.Servlet;


### PR DESCRIPTION
Add a new HttpServerConfiguration option to enable StatisticsHandler as the root handler (default off). Stats will be accessible via JMX if configured.