### PR TITLE
sort fields for deterministic order

### DIFF
--- a/ch-commons-util/src/main/java/com/cloudhopper/commons/util/MetaFieldUtil.java
+++ b/ch-commons-util/src/main/java/com/cloudhopper/commons/util/MetaFieldUtil.java
@@ -21,8 +21,8 @@ package com.cloudhopper.commons.util;
  */
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;

--- a/ch-commons-util/src/main/java/com/cloudhopper/commons/util/MetaFieldUtil.java
+++ b/ch-commons-util/src/main/java/com/cloudhopper/commons/util/MetaFieldUtil.java
@@ -21,7 +21,9 @@ package com.cloudhopper.commons.util;
  */
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -173,7 +175,13 @@ public class MetaFieldUtil {
         for (Class classType : hierarchy) {
             
             // begin search for each field (variable)
-            for (Field f : classType.getDeclaredFields()) {
+            Field[] fields = classType.getDeclaredFields();
+            Arrays.sort(fields, new Comparator<Field>() {
+                public int compare(Field a, Field b) {
+                    return a.getName().compareTo(b.getName());
+                }
+            });
+            for (Field f :  fields) {
 
                 // is this field marked as a MetaField?
                 if (f.isAnnotationPresent(MetaField.class)) {

--- a/ch-commons-util/src/test/java/com/cloudhopper/commons/util/MetaFieldUtilTest.java
+++ b/ch-commons-util/src/test/java/com/cloudhopper/commons/util/MetaFieldUtilTest.java
@@ -45,14 +45,14 @@ public class MetaFieldUtilTest {
         Administrator emp = new Administrator();
         MetaFieldInfo[] fields = MetaFieldUtil.toMetaFieldInfoArray(emp);
         Assert.assertEquals(12, fields.length);
-        Assert.assertEquals("First Name", fields[0].name);
-        Assert.assertEquals("Last Name", fields[1].name);
-        Assert.assertEquals("email", fields[2].name);
-        Assert.assertEquals("ID", fields[3].name);
-        Assert.assertEquals("Active?", fields[4].name);
+        Assert.assertEquals("email", fields[0].name);
+        Assert.assertEquals("First Name", fields[1].name);
+        Assert.assertEquals("ID", fields[2].name);
+        Assert.assertEquals("Active?", fields[3].name);
+        Assert.assertEquals("Last Name", fields[4].name);
         Assert.assertEquals("loginCounter", fields[5].name);
-        Assert.assertEquals("The first name of this user", fields[0].description);
-        Assert.assertEquals("", fields[1].description);
+        Assert.assertEquals("The first name of this user", fields[1].description);
+        Assert.assertEquals("", fields[0].description);
         Assert.assertEquals("", fields[2].description);
         // set some values
         emp.setFirstName("John");
@@ -61,9 +61,9 @@ public class MetaFieldUtilTest {
         //for (MetaFieldInfo field : fields) {
         //    logger.debug("field name=" + field.name + ", value=" + field.value + ", description=" + field.description);
         //}
-        Assert.assertEquals("John", fields[0].value);
-        Assert.assertEquals("Doe", fields[1].value);
-        Assert.assertEquals("EMPTY", fields[2].value);
+        Assert.assertEquals("EMPTY", fields[0].value);
+        Assert.assertEquals("John", fields[1].value);
+        Assert.assertEquals("Doe", fields[4].value);
     }
 
 


### PR DESCRIPTION
The tests
`com.cloudhopper.commons.util.MetaFieldUtilTest.toMetaFieldInfoArray`
is a flaky test, it can pass mvn test while but when run using the tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), it fails. NonDex is a tool that will introduce non-determinism in certain java collections.The test shows below

```
-------------------------------------------------------------------------------
Test set: com.cloudhopper.commons.util.MetaFieldUtilTest
-------------------------------------------------------------------------------
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.013 sec <<< FAILURE!
toMetaFieldInfoArray(com.cloudhopper.commons.util.MetaFieldUtilTest)  Time elapsed: 0.005 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[First Name]> but was:<[ID]>
	at org.junit.Assert.assertEquals(Assert.java:125)
	at org.junit.Assert.assertEquals(Assert.java:147)
	at com.cloudhopper.commons.util.MetaFieldUtilTest.toMetaFieldInfoArray(MetaFieldUtilTest.java:48)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:45)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:42)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:263)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:68)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:47)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:231)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:60)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:50)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:222)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:24)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:231)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:60)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:50)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:222)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:157)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:136)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:62)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:139)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
```

The root cause is that when executing `MetaFieldUtil.toMetaFieldInfoArray(emp)` in MetaFieldUtilTest.java, it will invoke the `internalToMetaFieldInfoArray`, which calls `java.lang.Class.getDeclaredFields`. The Java8 specification about `getDeclaredFields` is that "The elements in the returned array are not sorted and are not in any particular order", with reference here: https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html. Therefore, this test may fail due to a different order.

In order to make the `for(Field field : classType.getDeclaredFields())` iteration order stable and get rid of this non-deterministic behavior, this fix is to sort the Field array returned by getDeclaredFields() by its name and then change the order of the assertions in `toMetaFieldInfoArray` to match with the sorted order.