### PR TITLE
Header Image Missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Cloudhopper by Twitter [![Build Status](https://secure.travis-ci.org/twitter/cloudhopper-commons.png?branch=master)](http://travis-ci.org/twitter/cloudhopper-commons)
+Cloudhopper by Twitter [Build Status](http://travis-ci.org/twitter/cloudhopper-commons)
 ======================
 
 Common Java libraries used by the Cloudhopper family of mobile messaging applications at Twitter.


### PR DESCRIPTION
## Brief
The Heading of the README contains an Image which doesn't exist anymore making it look like unfound file.

## Previously
![Untitled](https://user-images.githubusercontent.com/70687014/233676194-2448f507-2a64-4446-8673-113914cbcc94.png)

## Now
![image](https://user-images.githubusercontent.com/70687014/233676098-cecaa9f9-14fb-441f-8b51-f9a3515b1d52.png)
