### PR TITLE
Fixed Flaky Test in WindowTest.java

### DIFF
--- a/ch-commons-util/src/test/java/com/cloudhopper/commons/util/windowing/WindowTest.java
+++ b/ch-commons-util/src/test/java/com/cloudhopper/commons/util/windowing/WindowTest.java
@@ -315,7 +315,8 @@ public class WindowTest {
         public void run() {
             try {
                 for (int x = 0; x < requestsPerThread; x++) {
-                    Integer i = Integer.valueOf(""+id+""+x);
+                    //To get a distinct value of i, we multiply id by the total number of requests per thread and add x to it
+                    Integer i = Integer.valueOf(""+id*requestsPerThread+""+x);
                     String request = "Request"+i;
  //                   logger.debug("adding request " + i);
                     WindowFuture<Integer,String,String> requestFuture = window.offer(i, request, 1000);


### PR DESCRIPTION
### Description
The test simulatedMultithreadedProcessing in the test class com.cloudhopper.commons.util.windowing.WindowTest could fail if the same key is generated by two different threads.

### Steps to reproduce
Run the test multiple times. The current logic to generate a key is:
Integer.valueOf(""+id+""+x);
Here id is a number between 0 and requestThreadCount-1
x is a number between 0 and requestsPerThread-1
However, this can generate duplicate keys in some scenarios. Eg- For id = 0, x = 26 -> Key is 26 and for id = 2, x = 6 -> Key is 26. This leads to a DuplicateKeyException being thrown.

This was identified by running [NonDex](https://github.com/TestingResearchIllinois/NonDex). 
The flaky tests can be found when running the following command:
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest={test}

### Expected Behaviour
All tests should pass

### Actual Behaviour
The test can fail if duplicate keys are generated.

### Solution
The logic of defining a key is updated to - Integer.valueOf(""+id*requestsPerThread+""+x);
This way there are no duplicate keys generated.